### PR TITLE
deprecation note

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # tap-min
 
+**Deprecated.** Please use the [`derhuerst/tap-min` fork](https://github.com/derhuerst/tap-min).
+
+---
+
 Minimal TAP output formatter.
 
 ## Installation


### PR DESCRIPTION
For the sake of transparency, I will submit this as a PR.

A while ago, the original maintainer of this repo gave me write access to update it. I published the latest `tap-min` from [my fork](https://github.com/derhuerst/tap-min).